### PR TITLE
Fix the index file resolution

### DIFF
--- a/DirectoryNameAsDefaultFile.js
+++ b/DirectoryNameAsDefaultFile.js
@@ -19,8 +19,7 @@ DirectoryDefaultFilePlugin.prototype.apply = function (resolver) {
       if (err || !stat) return done();
       if (!stat.isDirectory()) return done();
 
-      var index = resolver.join(req.path, req.request);
-      resolver.join(directory, 'index.js');
+      var index = resolver.join(directory, 'index.js');
 
       resolver.fileSystem.stat(index, function (err, stat) {
         if (!err && stat && stat.isFile()) {


### PR DESCRIPTION
With the index file resolution changes, `index` was being set to the require path, and nothing was appending `index.js`, so `resolver.fileSystem.stat` would always fail.

This PR fixes the `index` variable, so it actually points at the `index.js` file and correctly includes dependencies.