### PR TITLE
Ignore packages under node_modules directory

### DIFF
--- a/DirectoryNameAsDefaultFile.js
+++ b/DirectoryNameAsDefaultFile.js
@@ -18,6 +18,7 @@ DirectoryDefaultFilePlugin.prototype.apply = function (resolver) {
     resolver.fileSystem.stat(directory, function (err, stat) {
       if (err || !stat) return done();
       if (!stat.isDirectory()) return done();
+      if (directory.match(/node_modules/)) return done();
 
       var index = resolver.join(directory, 'index.js');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/webpack-directory-name-as-main",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Teach webpack to use the name of the directory as the main file for a module",
   "main": "DirectoryNameAsDefaultFile.js",
   "scripts": {


### PR DESCRIPTION
This fixes issue #1, where a warning is given when a third-party package has the same name as it's directory. Simply ignoring `node_modules` fixes this issue.